### PR TITLE
fix(typo): correct sensor name

### DIFF
--- a/integrations/nightmode.cpp
+++ b/integrations/nightmode.cpp
@@ -32,7 +32,7 @@ NightMode::NightMode(QObject *parent)
 
     m_switch = new Switch(this);
     m_switch->setId("nightmode_inhibit");
-    m_switch->setName("Night ode Inihibt");
+    m_switch->setName("Night Mode Inihibit");
     m_switch->setState(false); // the state is whether this switch is inhibiting the night mode, the sensor is if /anything/ is
     QObject::connect(m_switch, &Switch::stateChangeRequested, this, [this](bool state) {
         if (state) {


### PR DESCRIPTION
Fix typo in "Night Mode Inihibit" switch name
![image](https://github.com/user-attachments/assets/c31027f4-7c7f-4f12-9e8a-aea549188905)
